### PR TITLE
Fix date picker overflow in add-cash form

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -173,6 +173,15 @@ body {
   box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.1);
 }
 
+/* Fix date picker overflow */
+.form-group input[type="date"] {
+  position: relative;
+}
+
+.card:has(input[type="date"]) {
+  overflow: visible;
+}
+
 .form-group textarea {
   min-height: 100px;
   resize: vertical;


### PR DESCRIPTION
Add CSS rules to prevent the date picker calendar from being clipped by the card container. Uses position: relative on the date input and overflow: visible on cards containing date inputs.

Fixes #5