### PR TITLE
Fix date picker overflow on iOS mobile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -146,6 +146,7 @@ body {
 /* Forms */
 .form-group {
   margin-bottom: 20px;
+  overflow: hidden;
 }
 
 .form-group label {
@@ -176,11 +177,13 @@ body {
 
 /* Fix date picker overflow */
 .form-group input[type="date"] {
-  position: relative;
-}
-
-.card:has(input[type="date"]) {
-  overflow: visible;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
 }
 
 .form-group textarea {


### PR DESCRIPTION
- Add overflow: hidden to .form-group to clip any content extending beyond
- Set min-width: 0 on date input to allow it to shrink on mobile
- Add -moz-appearance for better cross-browser support

Fixes #5