### PR TITLE
Fix category relation: use separate categories database

### DIFF
--- a/js/add-cash.js
+++ b/js/add-cash.js
@@ -36,7 +36,21 @@ const AddCash = {
       const response = await API.getCategories();
       this.categories = response.categories || [];
 
-      Utils.populateSelect(select, this.categories, 'Select a category...');
+      // Populate select with category objects (value = id, label = spend_name)
+      select.innerHTML = '';
+      const placeholder = document.createElement('option');
+      placeholder.value = '';
+      placeholder.textContent = 'Select a category...';
+      placeholder.disabled = true;
+      placeholder.selected = true;
+      select.appendChild(placeholder);
+
+      this.categories.forEach(cat => {
+        const opt = document.createElement('option');
+        opt.value = cat.id;  // Store the Notion page ID
+        opt.textContent = cat.spend_name;  // Display the spend_name
+        select.appendChild(opt);
+      });
     } catch (error) {
       console.error('Failed to load categories:', error);
       // Show error but allow manual entry
@@ -69,14 +83,16 @@ const AddCash = {
     const submitBtn = Utils.$('submit-btn');
 
     // Get form data
-    const category = Utils.$('category').value;
+    const categoryId = Utils.$('category').value;  // This is now the Notion page ID
+    const categorySelect = Utils.$('category');
+    const categoryName = categorySelect.options[categorySelect.selectedIndex]?.text || '';
     const amount = parseFloat(Utils.$('amount').value);
     const currency = document.querySelector('input[name="currency"]:checked').value;
     const chargeDate = Utils.$('charge_date').value;
     const note = Utils.$('note').value.trim();
 
     // Validate
-    if (!category) {
+    if (!categoryId) {
       Utils.showAlert('alert-container', 'Please select a category.', 'error');
       return;
     }
@@ -105,11 +121,11 @@ const AddCash = {
 
       // Prepare data for API
       const data = {
-        transaction: note || `Cash - ${category}`,
-        spend_name: note || `Cash - ${category}`,
+        transaction: note || `Cash - ${categoryName}`,
+        spend_name: note || `Cash - ${categoryName}`,
         amount: amount,
         currency: currency,
-        category: category,
+        category_id: categoryId,  // Pass the Notion page ID for the relation
         charge_date: chargeDate,
         money_date: chargeDate,
         method: CONFIG.DEFAULTS.METHOD,

--- a/js/categorizer.js
+++ b/js/categorizer.js
@@ -135,16 +135,30 @@ const Categorizer = {
   /**
    * Categorize all transactions
    * @param {Array} transactions - Transactions to categorize
+   * @param {Array} categoriesList - List of category objects with id and spend_name
    * @returns {Array} - Transactions with categories applied
    */
-  categorizeAll(transactions) {
+  categorizeAll(transactions, categoriesList = []) {
     return transactions.map(tx => {
       const result = this.categorize(tx);
+
+      // Look up category_id from the categories list
+      let category_id = null;
+      if (result.category && categoriesList.length > 0) {
+        const matched = categoriesList.find(c =>
+          c.spend_name.toLowerCase() === result.category.toLowerCase()
+        );
+        if (matched) {
+          category_id = matched.id;
+        }
+      }
+
       return {
         ...tx,
         category: result.category,
+        category_id: category_id,
         matched_rule: result.matched_rule,
-        auto_categorized: result.auto_categorized
+        auto_categorized: result.auto_categorized && category_id !== null
       };
     });
   },

--- a/js/xlsx-parser.js
+++ b/js/xlsx-parser.js
@@ -109,6 +109,7 @@ const XLSXParser = {
 
       // To be filled by categorizer
       category: null,
+      category_id: null,
       auto_categorized: false,
       matched_rule: null,
 
@@ -159,7 +160,7 @@ const XLSXParser = {
    */
   getStats(transactions, fxRate) {
     const total = transactions.length;
-    const categorized = transactions.filter(t => t.category).length;
+    const categorized = transactions.filter(t => t.category_id).length;
     const uncategorized = total - categorized;
 
     // Calculate total in EUR

--- a/lambda/handlers/batch-spending.js
+++ b/lambda/handlers/batch-spending.js
@@ -104,13 +104,17 @@ async function createSingleSpending(tx, fxRate) {
     },
     amount: { number: parseFloat(tx.amount) },
     currency: { select: { name: tx.currency || 'EUR' } },
-    category: { select: { name: tx.category || 'Uncategorized' } },
     charge_date: { date: { start: tx.charge_date } },
     money_date: { date: { start: tx.charge_date } },
     type: { select: { name: 'spending' } },
     mm: { number: parseInt(tx.charge_date.split('-')[1], 10) },
     euro_money: { number: euroMoney }
   };
+
+  // Add category relation if category_id is provided
+  if (tx.category_id) {
+    properties.category = { relation: [{ id: tx.category_id }] };
+  }
 
   // Optional fields
   if (tx.method) {

--- a/lambda/handlers/spending.js
+++ b/lambda/handlers/spending.js
@@ -16,8 +16,8 @@ async function createSpending(event) {
     const data = JSON.parse(event.body || '{}');
 
     // Validate required fields
-    if (!data.amount || !data.category || !data.charge_date) {
-      return error('Missing required fields: amount, category, charge_date', 400);
+    if (!data.amount || !data.category_id || !data.charge_date) {
+      return error('Missing required fields: amount, category_id, charge_date', 400);
     }
 
     // Build Notion properties
@@ -27,7 +27,7 @@ async function createSpending(event) {
       },
       amount: { number: parseFloat(data.amount) },
       currency: { select: { name: data.currency || 'EUR' } },
-      category: { select: { name: data.category } },
+      category: { relation: [{ id: data.category_id }] },
       charge_date: { date: { start: data.charge_date } },
       money_date: { date: { start: data.charge_date } },
       type: { select: { name: 'spending' } },
@@ -108,11 +108,11 @@ async function getSpending(event) {
       });
     }
 
-    // Add category filter
+    // Add category filter (by relation page ID)
     if (category) {
       filters.push({
         property: 'category',
-        select: { equals: category }
+        relation: { contains: category }
       });
     }
 

--- a/lambda/notion-client.js
+++ b/lambda/notion-client.js
@@ -9,8 +9,9 @@ const notion = new Client({
   auth: process.env.NOTION_TOKEN
 });
 
-// Database ID from environment
+// Database IDs from environment
 const DATABASE_ID = process.env.SPENDING_DATABASE_ID;
+const CATEGORIES_DATABASE_ID = process.env.CATEGORIES_DATABASE_ID;
 
 // CORS headers for API Gateway
 const CORS_HEADERS = {
@@ -103,7 +104,7 @@ function extractPageData(page) {
     transaction: getTitle(props.transaction),
     amount: getNumber(props.amount),
     currency: getSelect(props.currency),
-    category: getSelect(props.category),
+    category: getRelation(props.category),
     charge_date: getDate(props.charge_date),
     money_date: getDate(props.money_date),
     method: getSelect(props.method),
@@ -137,9 +138,15 @@ function getRichText(prop) {
   return prop?.rich_text?.[0]?.text?.content || '';
 }
 
+function getRelation(prop) {
+  // Return first related page ID or null
+  return prop?.relation?.[0]?.id || null;
+}
+
 module.exports = {
   notion,
   DATABASE_ID,
+  CATEGORIES_DATABASE_ID,
   CORS_HEADERS,
   success,
   error,


### PR DESCRIPTION
Changes:
- Add CATEGORIES_DATABASE_ID env var for categories database
- GET /categories now queries categories database (not spending)
- POST /spending and /spending/batch use category relation (not select)
- Frontend passes category_id (Notion page ID) instead of category name
- Categorizer looks up category_id from categories list
- Update XLSX parser stats to use category_id

Environment variables required:
- NOTION_TOKEN
- SPENDING_DATABASE_ID (29313ec8894181fab424e008128e1b16)
- CATEGORIES_DATABASE_ID (29213ec889418016af65e32692292b15)