### PR TITLE
Add support for category name field in spending categories

### DIFF
--- a/js/clean-spending.js
+++ b/js/clean-spending.js
@@ -214,7 +214,7 @@ const CleanSpending = {
             <select class="category-select" data-index="${originalIndex}">
               <option value="">-- Select --</option>
               ${this.categories.map(c =>
-                `<option value="${c.id}" ${tx.category_id === c.id ? 'selected' : ''}>${c.spend_name}</option>`
+                `<option value="${c.id}" ${tx.category_id === c.id ? 'selected' : ''}>${c.name || c.spend_name}</option>`
               ).join('')}
             </select>
           </td>

--- a/lambda/handlers/categories.js
+++ b/lambda/handlers/categories.js
@@ -38,9 +38,15 @@ async function getCategories(event) {
           || props.spend_name?.title?.[0]?.text?.content
           || '';
 
+        // Get name (title) from the page
+        const name = props.name?.title?.[0]?.text?.content
+          || props.name?.rich_text?.[0]?.text?.content
+          || spendName;
+
         if (spendName) {
           categories.push({
             id: page.id,
+            name: name,
             spend_name: spendName,
             spend_id: props.spend_id?.rich_text?.[0]?.text?.content || '',
             spend_grp: props.spend_grp?.select?.name || props.spend_grp?.rich_text?.[0]?.text?.content || '',


### PR DESCRIPTION
## Summary
This PR adds support for an optional `name` field in spending categories, allowing categories to display a custom name while maintaining backward compatibility with the existing `spend_name` field.

## Changes
- **Lambda handler (`categories.js`)**: Updated the `getCategories` function to extract and include a `name` property from the Notion database, with fallback to `spend_name` if not present
- **Frontend (`clean-spending.js`)**: Modified the category dropdown rendering to display `name` when available, falling back to `spend_name` for backward compatibility

## Implementation Details
- The `name` field is extracted from Notion properties with the same pattern used for `spend_name` (checking both `title` and `rich_text` fields)
- If `name` is not available, it defaults to the `spend_name` value
- The frontend uses a logical OR operator (`||`) to gracefully handle cases where `name` may not exist, ensuring existing categories without a `name` field continue to work
- This change is fully backward compatible with existing category data