### PR TITLE
Fix extraction of euro_money formula property from Notion

### DIFF
--- a/lambda/notion-client.js
+++ b/lambda/notion-client.js
@@ -123,7 +123,15 @@ function getTitle(prop) {
 }
 
 function getNumber(prop) {
-  return prop?.number ?? null;
+  // Handle regular number properties
+  if (prop?.number !== undefined) {
+    return prop.number;
+  }
+  // Handle formula properties that return numbers
+  if (prop?.formula?.type === 'number') {
+    return prop.formula.number;
+  }
+  return null;
 }
 
 function getSelect(prop) {


### PR DESCRIPTION
The euro_money field is a formula column in Notion, not a regular number property. Formula properties have a different structure:
- Number property: { number: value }
- Formula property: { formula: { type: "number", number: value } }

Updated getNumber() to handle both property types.

https://claude.ai/code/session_01Ei5A7EHpYAvkBNKbnMRbEW