### PR TITLE
Add subtotals for category groups by spend_era_name in review table

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -590,6 +590,35 @@ tbody tr:hover {
   background: rgba(16, 185, 129, 0.03);
 }
 
+/* Era subtotal rows - highlighted grouping */
+.era-subtotal-row {
+  background: var(--bg-tertiary);
+  border-top: 2px solid var(--border-accent);
+}
+
+.era-subtotal-row td {
+  background: var(--bg-tertiary);
+  color: var(--accent-primary);
+  font-weight: 600;
+}
+
+.era-subtotal-row:hover {
+  background: var(--bg-elevated);
+}
+
+.era-subtotal-row:hover td {
+  background: var(--bg-elevated);
+}
+
+/* Category rows within era groups */
+.era-category-row td {
+  color: var(--text-secondary);
+}
+
+.era-category-row:hover td {
+  color: var(--text-primary);
+}
+
 /* Status Badges */
 .badge {
   display: inline-flex;

--- a/lambda/notion-client.js
+++ b/lambda/notion-client.js
@@ -112,6 +112,7 @@ function extractPageData(page) {
     mm: getNumber(props.mm),
     euro_money: getNumber(props.euro_money),
     spend_name: getRichText(props.spend_name),
+    spend_era_name: getSelect(props.spend_era_name),
     status: getSelect(props.status),
     created_time: page.created_time
   };


### PR DESCRIPTION
- Extract spend_era_name field in Lambda notion-client.js
- Update renderBudgetVsActual() to group spending by spend_era_name with subtotal rows at top of each era
- Update renderSpendingTrends() to group monthly data by spend_era_name with subtotals
- Add CSS styling for era subtotal rows with accent highlighting

Closes #20

https://claude.ai/code/session_0116iZfJNWjiW9dgkxNhvoqx