### PR TITLE
Add per-investment growth rate sliders for projections

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1135,6 +1135,57 @@ tr.uncategorized td:first-child {
   color: var(--accent-primary);
 }
 
+/* Inline Growth Slider in Portfolio Table */
+.growth-slider-cell {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 140px;
+}
+
+.growth-slider-cell .inv-growth-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 80px;
+  height: 4px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-full);
+  outline: none;
+  cursor: pointer;
+}
+
+.growth-slider-cell .inv-growth-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent-primary);
+  border: 2px solid var(--bg-primary);
+  box-shadow: 0 0 4px rgba(16, 185, 129, 0.3);
+  cursor: pointer;
+}
+
+.growth-slider-cell .inv-growth-slider::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent-primary);
+  border: 2px solid var(--bg-primary);
+  box-shadow: 0 0 4px rgba(16, 185, 129, 0.3);
+  cursor: pointer;
+}
+
+.growth-slider-cell .inv-growth-value {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--accent-primary);
+  min-width: 40px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
 /* Projection Table Styling */
 #projection-table tbody tr:last-child {
   border-bottom: 2px solid var(--border-accent);

--- a/investments.html
+++ b/investments.html
@@ -101,6 +101,7 @@
               <th style="text-align: right;">Return</th>
               <th style="text-align: right;">% Portfolio</th>
               <th>Status</th>
+              <th style="text-align: center;">Growth %</th>
             </tr>
           </thead>
           <tbody id="portfolio-table-body">
@@ -114,6 +115,7 @@
               <td style="text-align: right;" id="total-gain-loss">--</td>
               <td style="text-align: right;" id="total-return">--</td>
               <td style="text-align: right;">100%</td>
+              <td></td>
               <td></td>
             </tr>
           </tfoot>
@@ -174,7 +176,7 @@
           <h3 style="margin-bottom: 0;">5-Year Portfolio Projection</h3>
           <div style="display: flex; align-items: center; gap: 20px; flex-wrap: wrap;">
             <div class="range-control">
-              <label for="growth-rate-slider">Annual Growth</label>
+              <label for="growth-rate-slider">Set All Growth Rates</label>
               <div class="range-wrapper">
                 <input type="range" id="growth-rate-slider" min="0" max="20" step="0.5" value="7">
                 <span class="range-value" id="growth-rate-value">7.0%</span>

--- a/lambda/notion-client.js
+++ b/lambda/notion-client.js
@@ -142,6 +142,7 @@ function extractInvestmentData(page) {
     vest_date: getDate(props.vest_date),
     last_price_update: getDate(props.last_price_update),
     notes: getRichText(props.notes),
+    annual_growth_rate: getNumber(props.annual_growth_rate),
     created_time: page.created_time
   };
 }


### PR DESCRIPTION
- New Notion column: annual_growth_rate (number) on Investments DB
- Each row in portfolio table gets an inline growth rate slider (0-20%)
- Initial values loaded from Notion, defaults to 7% if unset
- Global "Set All" slider updates every individual slider at once
- Projection calculation uses per-investment quarterly compound rates
- Inline slider CSS styled to match the dark financial theme

https://claude.ai/code/session_01RjKzfSjzcSGh34zNdwwtyx