### PR TITLE
Fix allocations showing as undefined due to Notion percent format mismatch

### DIFF
--- a/js/investments.js
+++ b/js/investments.js
@@ -460,8 +460,10 @@ const Investments = {
       const weight = invValue / totalValue;
 
       // Find allocations for this investment matching the type
+      // Use case-insensitive comparison for allocation_type to handle
+      // Notion select values with different casing than radio button values
       const invAllocations = this.allocations.filter(a =>
-        a.allocation_type === type &&
+        a.allocation_type && a.allocation_type.toLowerCase() === type &&
         a.investment && a.investment.includes(inv.id)
       );
 

--- a/lambda/handlers/allocations.js
+++ b/lambda/handlers/allocations.js
@@ -32,6 +32,8 @@ async function createAllocation(event) {
     }
 
     // Build Notion properties
+    // The percentage property uses Notion's 'percent' format, which expects
+    // values as decimals (e.g. 0.5 for 50%). Convert from whole numbers (0-100).
     const properties = {
       name: {
         title: [{ text: { content: `${data.category} (${data.allocation_type})` } }]
@@ -41,7 +43,7 @@ async function createAllocation(event) {
       },
       allocation_type: { select: { name: data.allocation_type } },
       category: { select: { name: data.category } },
-      percentage: { number: data.percentage }
+      percentage: { number: data.percentage / 100 }
     };
 
     // Create the page

--- a/lambda/notion-client.js
+++ b/lambda/notion-client.js
@@ -155,13 +155,18 @@ function extractInvestmentData(page) {
 function extractAllocationData(page) {
   const props = page.properties;
 
+  // The percentage property uses Notion's 'percent' format, which stores
+  // values as decimals (e.g. 0.5 for 50%). Convert to whole numbers (0-100).
+  const rawPct = getNumber(props.percentage);
+  const percentage = rawPct != null ? rawPct * 100 : null;
+
   return {
     id: page.id,
     name: getTitle(props.name),
     investment: getRelation(props.investment),
     allocation_type: getSelect(props.allocation_type),
     category: getSelect(props.category),
-    percentage: getNumber(props.percentage)
+    percentage
   };
 }
 

--- a/lambda/scripts/setup-investments-db.js
+++ b/lambda/scripts/setup-investments-db.js
@@ -97,7 +97,8 @@ async function createAllocationsDatabase(investmentsDatabaseId) {
         select: {
           options: [
             { name: 'industry', color: 'blue' },
-            { name: 'geography', color: 'green' }
+            { name: 'geography', color: 'green' },
+            { name: 'fund', color: 'yellow' }
           ]
         }
       },


### PR DESCRIPTION
The allocations database percentage property uses Notion's 'percent' format,
which stores values as decimals (0.5 for 50%). The code was reading/writing
these as whole numbers (50 for 50%), causing weighted allocation values to be
100x too small and get filtered out. Also made allocation_type matching
case-insensitive and added missing 'fund' option to the setup script.

Fixes #37

https://claude.ai/code/session_01StVMz39VDfgEBfr8uAC9DC