### PR TITLE
Add cash spending link on login screen without requiring auth

### DIFF
--- a/add-cash.html
+++ b/add-cash.html
@@ -96,8 +96,14 @@
   <script src="js/add-cash.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      if (!Auth.requireAuth()) return;
-      Auth.initLogoutButton();
+      // This page works without authentication
+      if (Auth.isAuthenticated()) {
+        Auth.initLogoutButton();
+      } else {
+        // Hide logout button and other nav links that require auth
+        const logoutBtn = document.getElementById('logout-btn');
+        if (logoutBtn) logoutBtn.style.display = 'none';
+      }
       AddCash.init();
     });
   </script>

--- a/index.html
+++ b/index.html
@@ -21,6 +21,10 @@
         </div>
         <button type="submit" class="btn btn-primary btn-block">Login</button>
       </form>
+
+      <div style="text-align: center; margin-top: 24px; padding-top: 24px; border-top: 1px solid rgba(148, 163, 184, 0.1);">
+        <a href="add-cash.html" class="btn btn-outline btn-block">Add Cash Spending</a>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
The Add Cash Spending page can now be accessed directly from the login
screen without authentication, since adding a payment entry doesn't
require access to other protected modules.

https://claude.ai/code/session_01K5wqUptm7AQDGhEjM5pTkf