### PR TITLE
Fix graph legend visibility by changing color to white

### DIFF
--- a/js/investments.js
+++ b/js/investments.js
@@ -417,7 +417,7 @@ const Investments = {
           legend: {
             position: 'right',
             labels: {
-              color: '#94a3b8',
+              color: '#ffffff',
               font: { family: 'Inter, sans-serif' },
               padding: 16,
               generateLabels: (chart) => {
@@ -536,7 +536,7 @@ const Investments = {
           legend: {
             position: 'right',
             labels: {
-              color: '#94a3b8',
+              color: '#ffffff',
               font: { family: 'Inter, sans-serif' },
               padding: 14,
               generateLabels: (chart) => {
@@ -834,7 +834,7 @@ const Investments = {
           legend: {
             display: includeUnvested,
             labels: {
-              color: '#94a3b8',
+              color: '#ffffff',
               font: { family: 'Inter, sans-serif' },
               padding: 16
             }

--- a/js/review.js
+++ b/js/review.js
@@ -401,7 +401,7 @@ const Review = {
           legend: {
             position: 'top',
             labels: {
-              color: '#94a3b8',
+              color: '#ffffff',
               font: { family: 'Inter, sans-serif' },
               padding: 20
             }
@@ -559,7 +559,7 @@ const Review = {
           legend: {
             position: 'top',
             labels: {
-              color: '#94a3b8',
+              color: '#ffffff',
               font: { family: 'Inter, sans-serif' },
               padding: 16,
               boxWidth: 12


### PR DESCRIPTION
Changes legend label color from #94a3b8 (gray) to #ffffff (white) in all Chart.js charts across investments and review pages.

Fixes #36

https://claude.ai/code/session_01TPBZotB627Ny6BfuDopk6z